### PR TITLE
Remove section on stats, format markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,534 @@
+# Example markdownlint configuration with all properties set to their default value
+
+# Default state for all rules
+
+default: true
+
+# Path to configuration file to extend
+
+extends: null
+
+# MD001/heading-increment : Heading levels should only increment by one level at
+
+# a time
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md001.md>
+
+MD001: true
+
+# MD003/heading-style : Heading style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md003.md>
+
+MD003:
+
+# Heading style
+
+  style: "atx"
+
+# MD004/ul-style : Unordered list style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md004.md>
+
+MD004:
+
+# List style
+
+  style: "consistent"
+
+# MD005/list-indent : Inconsistent indentation for list items at the same level
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md005.md>
+
+MD005: true
+
+# MD007/ul-indent : Unordered list indentation
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md007.md>
+
+MD007:
+
+# Spaces for indent
+
+  indent: 2
+
+# Whether to indent the first level of the list
+
+  start_indented: false
+
+# Spaces for first level indent (when start_indented is set)
+
+  start_indent: 2
+
+# MD009/no-trailing-spaces : Trailing spaces
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md009.md>
+
+MD009:
+
+# Spaces for line break
+
+  br_spaces: 2
+
+# Allow spaces for empty lines in list items
+
+  list_item_empty_lines: false
+
+# Include unnecessary breaks
+
+  strict: false
+
+# MD010/no-hard-tabs : Hard tabs
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md010.md>
+
+MD010:
+
+# Include code blocks
+
+  code_blocks: true
+
+# Fenced code languages to ignore
+
+  ignore_code_languages: []
+
+# Number of spaces for each hard tab
+
+  spaces_per_tab: 4
+
+# MD011/no-reversed-links : Reversed link syntax
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md011.md>
+
+MD011: true
+
+# MD012/no-multiple-blanks : Multiple consecutive blank lines
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md012.md>
+
+MD012:
+
+# Consecutive blank lines
+
+  maximum: 1
+
+# MD013/line-length : Line length
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md013.md>
+
+MD013:
+
+# Number of characters
+
+  line_length: 80
+
+# Number of characters for headings
+
+  heading_line_length: 80
+
+# Number of characters for code blocks
+
+  code_block_line_length: 80
+
+# Include code blocks
+
+  code_blocks: true
+
+# Include tables
+
+  tables: true
+
+# Include headings
+
+  headings: true
+
+# Strict length checking
+
+  strict: false
+
+# Stern length checking
+
+  stern: false
+
+# MD014/commands-show-output : Dollar signs used before commands without showing
+
+# output
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md014.md>
+
+MD014: true
+
+# MD018/no-missing-space-atx : No space after hash on atx style heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md018.md>
+
+MD018: true
+
+# MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md019.md>
+
+MD019: true
+
+# MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style
+
+# heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md020.md>
+
+MD020: true
+
+# MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed
+
+# atx style heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md021.md>
+
+MD021: true
+
+# MD022/blanks-around-headings : Headings should be surrounded by blank lines
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md022.md>
+
+MD022:
+
+# Blank lines above heading
+
+  lines_above: 1
+
+# Blank lines below heading
+
+  lines_below: 1
+
+# MD023/heading-start-left : Headings must start at the beginning of the line
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md023.md>
+
+MD023: true
+
+# MD024/no-duplicate-heading : Multiple headings with the same content
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md024.md>
+
+MD024:
+
+# Only check sibling headings
+
+  siblings_only: true
+
+# MD025/single-title/single-h1 : Multiple top-level headings in the same
+
+# document
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md025.md>
+
+MD025:
+
+# Heading level
+
+  level: 1
+
+# RegExp for matching title in front matter
+
+# Disabled to avoid conflicts for GitHub Issue and PR Templates
+
+  front_matter_title: ""
+
+# MD026/no-trailing-punctuation : Trailing punctuation in heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md026.md>
+
+MD026:
+
+# Punctuation characters
+
+  punctuation: ".,;:!。，；：！"
+
+# MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md027.md>
+
+MD027: true
+
+# MD028/no-blanks-blockquote : Blank line inside blockquote
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md028.md>
+
+MD028: true
+
+# MD029/ol-prefix : Ordered list item prefix
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md029.md>
+
+MD029:
+
+# List style
+
+  style: "one_or_ordered"
+
+# MD030/list-marker-space : Spaces after list markers
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md030.md>
+
+MD030:
+
+# Spaces for single-line unordered list items
+
+  ul_single: 1
+
+# Spaces for single-line ordered list items
+
+  ol_single: 1
+
+# Spaces for multi-line unordered list items
+
+  ul_multi: 1
+
+# Spaces for multi-line ordered list items
+
+  ol_multi: 1
+
+# MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank
+
+# lines
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md031.md>
+
+MD031:
+
+# Include list items
+
+  list_items: true
+
+# MD032/blanks-around-lists : Lists should be surrounded by blank lines
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md032.md>
+
+MD032: true
+
+# MD033/no-inline-html : Inline HTML
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md033.md>
+
+MD033: false
+
+# MD034/no-bare-urls : Bare URL used
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md034.md>
+
+MD034: true
+
+# MD035/hr-style : Horizontal rule style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md035.md>
+
+MD035:
+
+# Horizontal rule style
+
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading : Emphasis used instead of a heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md036.md>
+
+MD036:
+
+# Punctuation characters
+
+  punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis : Spaces inside emphasis markers
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md037.md>
+
+MD037: true
+
+# MD038/no-space-in-code : Spaces inside code span elements
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md038.md>
+
+MD038: true
+
+# MD039/no-space-in-links : Spaces inside link text
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md039.md>
+
+MD039: true
+
+# MD040/fenced-code-language : Fenced code blocks should have a language
+
+# specified
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md>
+
+MD040:
+
+# List of languages
+
+  allowed_languages: []
+
+# Require language only
+
+  language_only: false
+
+# MD041/first-line-heading/first-line-h1 : First line in a file should be a
+
+# top-level heading
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md041.md>
+
+MD041:
+
+# Heading level
+
+  level: 1
+
+# RegExp for matching title in front matter
+
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD042/no-empty-links : No empty links
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md042.md>
+
+MD042: true
+
+# MD043/required-headings : Required heading structure
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md043.md>
+
+MD043: false
+
+# MD044/proper-names : Proper names should have the correct capitalization
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md044.md>
+
+MD044:
+
+# List of proper names
+
+  names: []
+
+# Include code blocks
+
+  code_blocks: true
+
+# Include HTML elements
+
+  html_elements: true
+
+# MD045/no-alt-text : Images should have alternate text (alt text)
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md045.md>
+
+MD045: true
+
+# MD046/code-block-style : Code block style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md046.md>
+
+MD046:
+
+# Block style
+
+  style: "consistent"
+
+# MD047/single-trailing-newline : Files should end with a single newline
+
+# character
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md047.md>
+
+MD047: true
+
+# MD048/code-fence-style : Code fence style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md048.md>
+
+MD048:
+
+# Code fence style
+
+  style: "consistent"
+
+# MD049/emphasis-style : Emphasis style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md049.md>
+
+MD049:
+
+# Emphasis style
+
+  style: "consistent"
+
+# MD050/strong-style : Strong style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md050.md>
+
+MD050:
+
+# Strong style
+
+  style: "consistent"
+
+# MD051/link-fragments : Link fragments should be valid
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md051.md>
+
+MD051: true
+
+# MD052/reference-links-images : Reference links and images should use a label
+
+# that is defined
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md052.md>
+
+MD052:
+
+# Include shortcut syntax
+
+  shortcut_syntax: false
+
+# MD053/link-image-reference-definitions : Link and image reference definitions
+
+# should be needed
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md053.md>
+
+MD053:
+
+# Ignored definitions
+
+  ignored_definitions:
+    - "//"
+
+# MD054/link-image-style : Link and image style
+
+# <https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md054.md>
+
+MD054:
+
+# Allow autolinks
+
+  autolink: true
+
+# Allow inline links and images
+
+  inline: true
+
+# Allow full reference links and images
+
+  full: true
+
+# Allow collapsed reference links and images
+
+  collapsed: true
+
+# Allow shortcut reference links and images
+
+  shortcut: true
+
+# Allow URLs as inline links
+
+  url_inline: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!--
-**Marlon-Gomes/Marlon-Gomes** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+**Marlon-Gomes/Marlon-Gomes** is a ✨ _special_ ✨ repository because its
+`README.md` (this file) appears on your GitHub profile.
 
 Here are some ideas to get you started:
 
@@ -13,110 +14,162 @@ Here are some ideas to get you started:
 - ⚡ Fun fact: ...
 -->
 
-## Hi there, I'm Marlon :wave:
+# Hi there, I'm Marlon :wave:
 
-### About me
-I am an Investment Analyst working in the NY metro area. My background is in Mathematics (I received my Ph.D. from Stony Brook University in 2020), specifically Differential Geometry. My work employs methods of Statistics, Information Geometry, and Machine Learning to the study of financial time series, primarily using Python and the Wolfram Language/Mathematica. I enjoy coding as a hobby.
+## About me
+
+I am an Investment Analyst working in the NY metro area. My background is in
+Mathematics (I received my Ph.D. from Stony Brook University in 2020),
+specifically Differential Geometry. My work employs methods of Statistics,
+Information Geometry, and Machine Learning to the study of financial time
+series, primarily using Python and the Wolfram Language/Mathematica. I enjoy
+coding as a hobby.
 
 - :books: I’m currently learning about
-    - C++
-    - Lua
-    - Cryptography
-    - Game development
+  - C++
+  - Lua
+  - Cryptography
+  - Game development
 - :handshake: I’m looking to collaborate on open source projects
 
+## :capital_abcd: Languages
 
-### :capital_abcd: Languages
 I'm familiar with the following languages, to various degrees of proficiency.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/github/explore/180320cffc25f4ed1bbdfd33d4db3a66eeeeb358/topics/cpp/cpp.png" alt="CPP" height="40" style="vertical-align:top; margin:4px">
-<img src="images/css.png" alt="CSS" height="40" style="vertical-align:top; margin:4px">
-<img src="https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/48/000000/external-html-5-is-a-software-solution-stack-that-defines-the-properties-and-behaviors-of-web-page-logo-shadow-tal-revivo.png" alt="HTML" height="40" style="vertical-align:top; margin:4px">
-<img src="images/latex.png" alt="LaTeX" height="40" style="vertical-align:top; margin:4px">
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png" alt = "Lua" height ="40" style = "vertical-align:top; margin:4px">
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/python/python.png" alt="Python" height="40" style="vertical-align:top; margin:4px">
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/swift/swift.png" alt="Swift" height="40" style="vertical-align:top; margin:4px">
-<img src="images/Wolfram_Language_Logo_2016.svg" alt="Wolfram Language" height="40" style="vertical-align:top; margin:4px">
+<img src="https://raw.githubusercontent.com/github/explore/180320cffc25f4ed1bbdfd33d4db3a66eeeeb358/topics/cpp/cpp.png"
+    alt="CPP" height="40" style="vertical-align:top; margin:4px">
+<img src="images/css.png" alt="CSS" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/48/000000/external-html-5-is-a-software-solution-stack-that-defines-the-properties-and-behaviors-of-web-page-logo-shadow-tal-revivo.png"
+    alt="HTML" height="40" style="vertical-align:top; margin:4px">
+<img src="images/latex.png" alt="LaTeX" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/lua/lua.png"
+    alt="Lua" height ="40" style = "vertical-align:top; margin:4px">
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/python/python.png"
+    alt="Python" height="40" style="vertical-align:top; margin:4px">
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/swift/swift.png"
+    alt="Swift" height="40" style="vertical-align:top; margin:4px">
+<img src="images/Wolfram_Language_Logo_2016.svg" alt="Wolfram Language"
+    height="40" style="vertical-align:top; margin:4px">
 </p>
 
-### :gear: Libraries and Frameworks
+## :gear: Libraries and Frameworks
 
 I employ the following Libraries and Frameworks often.
 
-#### Numerics, Data Analysis, and Statistics
+### Numerics, Data Analysis, and Statistics
+
 <p align="center">
-    <img src="images/Numpy.svg" alt="Numpy" height="50" style="vertical-align:top; margin:0px">
-    <img src="images/Pandas_logo.svg" alt="Pandas" height="40" style="vertical-align:top; margin:4px">
-    <img src="images/Scipy.svg" alt="Scipy" height="50" style="vertical-align:top; margin:0px">
-    <img src="images/Statsmodels.svg" alt="Statsmodels" height="50" style="vertical-align:top; margin:0px">
+    <img src="images/Numpy.svg" alt="Numpy" height="50"
+        style="vertical-align:top; margin:0px">
+    <img src="images/Pandas_logo.svg" alt="Pandas" height="40"
+        style="vertical-align:top; margin:4px">
+    <img src="images/Scipy.svg" alt="Scipy" height="50"
+        style="vertical-align:top; margin:0px">
+    <img src="images/Statsmodels.svg" alt="Statsmodels" height="50"
+        style="vertical-align:top; margin:0px">
 </p>
 
-#### Visualization
+### Visualization
+
 <p align="center">
-    <img src="images/matplotlib.svg" alt="Matplotlib" height="40" style="vertical-align:top; margin:4px">
-    <img src="https://seaborn.pydata.org/_images/logo-wide-lightbg.svg" alt="Seaborn" height="40" style="vertical-align:top; margin:4px">
+    <img src="images/matplotlib.svg" alt="Matplotlib" height="40"
+        style="vertical-align:top; margin:4px">
+    <img src="https://seaborn.pydata.org/_images/logo-wide-lightbg.svg"
+        alt="Seaborn" height="40" style="vertical-align:top; margin:4px">
 </p>
 
-#### Machine Learning
+### Machine Learning
+
 <p align="center">
-<img src="images/Scikit_learn_logo.svg" alt="SciKit Learn" height="40" style="vertical-align:top; margin:4px">
-<img src="images/Tensorflow_logo.svg" alt="TensorFlow" height="40" style="vertical-align:top; margin:4px">
+<img src="images/Scikit_learn_logo.svg" alt="SciKit Learn" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="images/Tensorflow_logo.svg" alt="TensorFlow" height="40"
+    style="vertical-align:top; margin:4px">
 </p>
 
-#### Web Development
+### Web Development
+
 <p align="center">
-    <img src="images/flask-logo.png" alt="Flask" height="40" style="vertical-align:top; margin:4px">
+    <img src="images/flask-logo.png" alt="Flask" height="40"
+        style="vertical-align:top; margin:4px">
 </p>
 
-### :hammer_and_wrench: Tools
+## :hammer_and_wrench: Tools
+
 I use the following suite of tools
 
-#### Editors and IDEs
-<p align="center">
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/atom/atom.png" alt="Atom" height="40" style="vertical-align:top; margin:4px">
-<img src="images/Eclipse.png" alt="Eclipse" height="40" style="vertical-align:top; margin:4px">
-<img src="images/spyder.png" alt="Spyder" height="40" style="vertical-align:top; margin:4px">
-<img src="images/texmaker.png" alt="TeXMaker" height="40" style="vertical-align:top; margin:4px">
-<img src="images/xcode.png" alt="Xcode" height="40" style="vertical-align:top; margin:4px">
-</p>
-
-#### Version Control
+### Editors and IDEs
 
 <p align="center">
-<img src="images/git.png" alt="Git" height="40" style="vertical-align:top; margin:4px">
-<img src="images/GitHub.png" alt="Github" height="40" style="vertical-align:top; margin:4px">
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/atom/atom.png"
+    alt="Atom" height="40" style="vertical-align:top; margin:4px">
+<img src="images/Eclipse.png" alt="Eclipse" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="images/spyder.png" alt="Spyder" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="images/texmaker.png" alt="TeXMaker" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="images/xcode.png" alt="Xcode" height="40"
+    style="vertical-align:top; margin:4px">
 </p>
 
-#### Notebook Environments
+### Version Control
+
 <p align="center">
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/jupyter-notebook/jupyter-notebook.png" alt="Jupyter Notebooks" height="40" style="vertical-align:top; margin:4px">
-<img src="images/Mathematica_Logo.svg" alt="Mathematica" height="40" style="vertical-align:top; margin:4px">
+<img src="images/git.png" alt="Git" height="40"
+    style="vertical-align:top; margin:4px">
+<img src="images/GitHub.png" alt="Github" height="40"
+    style="vertical-align:top; margin:4px">
 </p>
 
+### Notebook Environments
+
+<p align="center">
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/jupyter-notebook/jupyter-notebook.png"
+alt="Jupyter Notebooks"height="40" style="vertical-align:top; margin:4px">
+<img src="images/Mathematica_Logo.svg" alt="Mathematica" height="40"
+    style="vertical-align:top; margin:4px">
+</p>
 
 ### :trophy: My Github Stats
+
+<!-- TODO: FIX THIS
 <div>
-    <a href="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api/top-langs/?username=marlon-gomes&count_private=true&layout=compact&langs_count=10&theme=radical&hide_border=true" target = "_blank" title ="Most used languages">
-        <img align="center" src="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api/top-langs/?username=marlon-gomes&count_private=true&layout=compact&langs_count=10&theme=radical&hide_border=true" width="39%" height="195">
+    <a href="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api/top-langs/?username=marlon-gomes&count_private=true&layout=compact&langs_count=10&theme=radical&hide_border=true"
+        target = "_blank" title ="Most used languages">
+        <img align="center" src="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api/top-langs/?username=marlon-gomes&count_private=true&layout=compact&langs_count=10&theme=radical&hide_border=true"
+            width="39%" height="195">
     </a>
-    <a href="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api?username=marlon-gomes&theme=radical&include_all_commits=true&count_private=true&custom_title=Activity%20Stats&show_icons=true&hide_border=true" target = "_blank" title = "GitHub Stats">
-        <img align="center" src="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api?username=marlon-gomes&theme=radical&include_all_commits=true&count_private=true&custom_title=Activity%20Stats&show_icons=true&hide_border=true" width="60%" height = "195">
+    <a href="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api?username=marlon-gomes&theme=radical&include_all_commits=true&count_private=true&custom_title=Activity%20Stats&show_icons=true&hide_border=true"
+        target = "_blank" title = "GitHub Stats">
+        <img align="center" src="https://github-readme-stats-git-master-marlon-gomes.vercel.app/api?username=marlon-gomes&theme=radical&include_all_commits=true&count_private=true&custom_title=Activity%20Stats&show_icons=true&hide_border=true"
+            width="60%" height = "195">
     </a>
 </div>
+-->
+## 📫 How to reach me
 
-### 📫 How to reach me:
 <p align = "center">
 <a href="https://marlon-gomes.github.io" target = "_blank">
-    <img align="center" src="https://img.shields.io/badge/-Personal%20Webpage-white?style=flat-square&logo=Safari&logoColor=black&link=https://marlon-gomes.github.io">  
+    <img align="center" alt="Personal Webpage Link"
+        src="https://img.shields.io/badge/-Personal%20Webpage-white?style=flat-square&logo=Safari&logoColor=black&link=https://marlon-gomes.github.io">
 </a>
-<a href="mailto:72144990+Marlon-Gomes@users.noreply.github.com" target = "_blank">
-    <img align="center" src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" height = 20>
+<a href="mailto:72144990+Marlon-Gomes@users.noreply.github.com"
+    target = "_blank">
+    <img align="center" alt="Link to Mail"
+        src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white"
+        height = 20>
 </a>
-<a href="https://www.linkedin.com/in/marlon-deoliveiragomes" target = "_blank">
-    <img align="center" src="https://img.shields.io/badge/-LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white&link=www.linkedin.com/in/marlon-deoliveiragomes">
+<a href="https://www.linkedin.com/in/marlon-deoliveiragomes"
+    target = "_blank">
+    <img align="center" alt="LinkedIn Profile"
+        src="https://img.shields.io/badge/-LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white&link=www.linkedin.com/in/marlon-deoliveiragomes">
 </a>
 <a href="https://github.com/marlon-gomes" target = "_blank">
-    <img align="center" src="https://img.shields.io/github/followers/marlon-gomes?label=follow&style=social">
+    <img align="center" alt="Follow me on GitHub!"
+        src="https://img.shields.io/github/followers/marlon-gomes?label=follow&style=social">
 </a>
 </p>


### PR DESCRIPTION
Stats section relied on the deployment of an external repository (a fork of
github-readme-stats) on Vercel to run. We want something mush simpler than that, and decided to roll out our own solution.

Also added a markdown format config file and ran the formatter/edited by hand until no errors were shown.